### PR TITLE
refactor: Enhance error handling and timeout configuration in LLM client

### DIFF
--- a/loader/src/intelligent_ingestion.rs
+++ b/loader/src/intelligent_ingestion.rs
@@ -134,7 +134,8 @@ impl IntelligentRepositoryAnalyzer {
                         Err(e2) => {
                             return Err(anyhow!(
                                 "Repository analysis failed: {} (fallback failed: {})",
-                                e, e2
+                                e,
+                                e2
                             ));
                         }
                     }


### PR DESCRIPTION
- Updated the LLM client to implement a fallback mechanism to OpenAI when the primary Claude provider fails, improving robustness in repository analysis.
- Refactored the output handling to utilize a configurable timeout for process completion, defaulting to 120 seconds.
- Adjusted the subproject commit reference in the `cto` documentation to indicate a dirty state.

These changes improve error management and flexibility in the LLM client, ensuring more reliable interactions with external services.